### PR TITLE
Assignment with booleans constant bug

### DIFF
--- a/src/rowdy/Rowdy.java
+++ b/src/rowdy/Rowdy.java
@@ -492,7 +492,7 @@ public class Rowdy {
         for (int p = 1; p < args.length; p++) {
           String in = args[p];
           if (Character.isDigit(in.charAt(0))) {
-            programParameters.add(new Value(Float.parseFloat(args[p])));
+            programParameters.add(new Value(Double.parseDouble(args[p])));
           } else {
             String argStr = args[p];
             if (argStr.equals("true") || argStr.equals("false")) {

--- a/src/rowdy/RowdyRunner.java
+++ b/src/rowdy/RowdyRunner.java
@@ -510,7 +510,7 @@ public class RowdyRunner {
         throw new RuntimeException("The ID '" + value + "' doesn't exist "
                 + "on line " + curSeq.getLine());
       }
-      return val;
+      return new Value(val);
     } else {
       return value;
     }

--- a/src/rowdy/Value.java
+++ b/src/rowdy/Value.java
@@ -19,6 +19,10 @@ public class Value {
     this.isConstant = isConstant;
   }
   
+  public Value(Value v){
+    this(v.getValue(), false);
+  }
+  
   public Value(Object value) {
     this(value, false);
   }


### PR DESCRIPTION
When allocating simple fix found with instead of passing the value directly from the symbol table create a new value with a copy constructor. Pass the old value into the constructor and copy the value over making the variable not become a constant